### PR TITLE
dex selector fades if selecting pokemon that is not caught

### DIFF
--- a/js/dex.js
+++ b/js/dex.js
@@ -106,6 +106,8 @@ class Dex {
 
             this.dexInfoElement.removeClass('collapsed');
             this.dexInfoElement.removeClass('hidden');
+        } else {
+            this.hideInfo();
         }
     }
 
@@ -113,6 +115,7 @@ class Dex {
         this.dexInfoElement.addClass('hidden');
         setTimeout(() => {
             this.dexInfoElement.addClass('collapsed');
+            $('.selected').removeClass('selected');
         }, 425);
     }
 


### PR DESCRIPTION
selected pokemon is unselected when info box closes